### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2020-08-17T10:36:48Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,320 +53,408 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
     "spec/fixtures/events.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "18ad63f50e7240333f4f2827b02fde57d52b438a",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 114,
-        "type": "Hex High Entropy String"
+        "line_number": 23,
+        "is_secret": false
       },
       {
-        "hashed_secret": "ea21d8ae36a08380bf834049f8fec5577f30a624",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 520,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "e66ea2a7a199891c3268896ba03a48e7560ff95e",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 931,
-        "type": "Hex High Entropy String"
+        "line_number": 24,
+        "is_secret": false
       },
       {
-        "hashed_secret": "57b04936dfb090a3e2f5b2641ebcc8ae428cedb8",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "ea21d8ae36a08380bf834049f8fec5577f30a624",
         "is_verified": false,
-        "line_number": 1337,
-        "type": "Hex High Entropy String"
+        "line_number": 27,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "9a855848e944a56405720b62fa64a3a3f9c654ab",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 1748,
-        "type": "Hex High Entropy String"
+        "line_number": 841,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "57b04936dfb090a3e2f5b2641ebcc8ae428cedb8",
+        "is_verified": false,
+        "line_number": 844,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "771fa63e20791ea547feff96be10fde38d1b0a9d",
+        "is_verified": false,
+        "line_number": 1658,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "5887d01dfa24873e3459052e55059bf80d3931ca",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2107,
-        "type": "Hex High Entropy String"
+        "line_number": 1661,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "f4092a378e77b32415ffcb7538771860cb2e6c17",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2153,
-        "type": "Hex High Entropy String"
+        "line_number": 2104,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "f51aa5262601cbf31d3c12faeca9bab4798125ce",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2199,
-        "type": "Hex High Entropy String"
+        "line_number": 2150,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "4baf5f1c0ac4e6805569538fc7d8760303027567",
+        "is_verified": false,
+        "line_number": 2196,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "045c8f4eb1bfc798524bfaa7ae6ad9ca7ce9d809",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 2613,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
-        "hashed_secret": "4baf5f1c0ac4e6805569538fc7d8760303027567",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2616,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "771fa63e20791ea547feff96be10fde38d1b0a9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2749,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "1bdf6e6325f8939902b5d16a7b95a8ee0e11c7c1",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 3223,
-        "type": "Hex High Entropy String"
+        "line_number": 2659,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "a32a3b6068e07e5ad87bfe44cc71af0968dfc14d",
+        "is_verified": false,
+        "line_number": 2662,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "8b3f79015af1931977b459f84e5843a32b7d94b1",
+        "is_verified": false,
+        "line_number": 2918,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "dfc20f15a1529e44cecabeff1d1caf9f40b838b1",
+        "is_verified": false,
+        "line_number": 3136,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "a41b865e0987d33eeb37fd587ccd963c69a10930",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 3613,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "ff91c2a6c06f7669d453dcf41cec590d4e2ecc30",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 3629,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "0d69abab66d7c0475a3e8aeb29fb94ac2ded5ad6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 3754,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "9aceca36b39079f68d8fdf41a80df29547f60f0c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 4321,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
-        "hashed_secret": "dfc20f15a1529e44cecabeff1d1caf9f40b838b1",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "7ea47c274fa1821a6d657c350fd2bace5cd98a76",
         "is_verified": false,
-        "line_number": 4324,
-        "type": "Hex High Entropy String"
+        "line_number": 4738,
+        "is_secret": false
       },
       {
-        "hashed_secret": "a32a3b6068e07e5ad87bfe44cc71af0968dfc14d",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "08f5da63ba9e695af8fe26a95a9c7702b32a70cd",
         "is_verified": false,
-        "line_number": 4417,
-        "type": "Hex High Entropy String"
+        "line_number": 4741,
+        "is_secret": false
       },
       {
-        "hashed_secret": "8b3f79015af1931977b459f84e5843a32b7d94b1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4828,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "c286dc580efadeb997085694aa6013b559cf0941",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 5212,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
-        "hashed_secret": "08f5da63ba9e695af8fe26a95a9c7702b32a70cd",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "1577a73fc5c6cf4eff48718246ec6f18ae44fd8d",
         "is_verified": false,
-        "line_number": 5275,
-        "type": "Hex High Entropy String"
+        "line_number": 5215,
+        "is_secret": false
       },
       {
-        "hashed_secret": "7ea47c274fa1821a6d657c350fd2bace5cd98a76",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "789a91088ef6da8ebbed3645eee66c023eb68245",
         "is_verified": false,
-        "line_number": 5721,
-        "type": "Hex High Entropy String"
+        "line_number": 5225,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "1c417b6d17b3026aed72d3772a89fc7ba2bd96a9",
+        "is_verified": false,
+        "line_number": 5235,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "b3cdeb41935a38ea5dc914cb3bffff78ffd2fb24",
+        "is_verified": false,
+        "line_number": 5245,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "a4e197df17e2a623d991c864ba831e8e1185e0b8",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 5814,
-        "type": "Hex High Entropy String"
+        "line_number": 5255,
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "4ffc43b9aeda910d8992ec450b1d1da3123465c1",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6169,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
+        "hashed_secret": "e5a512c2da4d19fafcb9bdc89710a1f33d5e278e",
+        "is_verified": false,
+        "line_number": 6213,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "349bfa72e1c91a7dd097c4909dc818054f1bc963",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6584,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
-        "hashed_secret": "e5a512c2da4d19fafcb9bdc89710a1f33d5e278e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6955,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "b3cdeb41935a38ea5dc914cb3bffff78ffd2fb24",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7366,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "1577a73fc5c6cf4eff48718246ec6f18ae44fd8d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7410,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "39ee5f723953d17c84b0acd264c34bae22abd662",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7535,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "d2ca5534d27412e070d46a20abf8dc3c05735569",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 8168,
-        "type": "Hex High Entropy String"
+        "line_number": 7953,
+        "is_secret": false
       },
       {
-        "hashed_secret": "789a91088ef6da8ebbed3645eee66c023eb68245",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8171,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "1c417b6d17b3026aed72d3772a89fc7ba2bd96a9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8181,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "9ce9505fc6ad4a68a1423f88dba442186459b24f",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 8258,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "c6f5bbe1142ed3c285d2847538e3f29348c7daf5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 8302,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/events.json",
         "hashed_secret": "8e63741a7bacc6a42b7bd3ac9867dfd58795667c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 8427,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "spec/fixtures/one_pr": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/one_pr",
         "hashed_secret": "9616f77911c0382d2fe9c69bac6a86bb975f4ad7",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 41,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/one_pr",
         "hashed_secret": "0ab848a2d5e11110d795625fb2871802150da80a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 58,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/one_pr",
         "hashed_secret": "5b9f7e82c4bbd019f559d53021aff8fd92d5cdce",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 204,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "spec/fixtures/one_pr.json": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/one_pr.json",
         "hashed_secret": "18ad63f50e7240333f4f2827b02fde57d52b438a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 38,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/one_pr.json",
         "hashed_secret": "ea21d8ae36a08380bf834049f8fec5577f30a624",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 54,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "spec/fixtures/one_pr.json",
         "hashed_secret": "e66ea2a7a199891c3268896ba03a48e7560ff95e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 179,
-        "type": "Hex High Entropy String"
+        "is_secret": false
       }
     ],
     "spec/pull_request_spec.rb": [
       {
-        "hashed_secret": "5887d01dfa24873e3459052e55059bf80d3931ca",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "spec/pull_request_spec.rb",
+        "hashed_secret": "ea21d8ae36a08380bf834049f8fec5577f30a624",
         "is_verified": false,
-        "line_number": 64,
-        "type": "Hex High Entropy String"
+        "line_number": 56,
+        "is_secret": false
       },
       {
-        "hashed_secret": "ea21d8ae36a08380bf834049f8fec5577f30a624",
-        "is_secret": false,
+        "type": "Hex High Entropy String",
+        "filename": "spec/pull_request_spec.rb",
+        "hashed_secret": "5887d01dfa24873e3459052e55059bf80d3931ca",
         "is_verified": false,
-        "line_number": 71,
-        "type": "Hex High Entropy String"
+        "line_number": 64,
+        "is_secret": false
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T17:08:30Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`